### PR TITLE
Refactor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 project(matcher LANGUAGES C CXX)
 
 enable_testing()

--- a/src/lib/limit.cpp
+++ b/src/lib/limit.cpp
@@ -6,32 +6,37 @@ Limit::Limit(std::shared_ptr<Order> order)
 , s_volume(order->units)
 {
 	s_orders.push_back(order);
-	s_orderMap[order->id] = order;
+	s_orderMap[order->id] = s_orders.begin();
 }
 
 void Limit::addOrderToLimit(std::shared_ptr<Order> order)
 {
 	s_volume += order->units;
 	s_orders.push_back(order);
-	s_orderMap[order->id] = order;
+	s_orderMap[order->id] = s_orders.end()--;
 }
 
-void Limit::fillUnits(int units)
+std::vector<int> Limit::fillUnits(int units)
 {
+	std::vector<int> filledOrders;
 	while(units){
 		auto head = s_orders.front();
 		if(units >= head->units){
 			units -= head->units;
 			s_volume -= head->units;
 
+			filledOrders.push_back(head->id);
 			s_orders.pop_front();
 			s_orderMap.erase(head->id);
 		}
 		else{
 			head->units -= units;
+			s_volume -= units;
 			units = 0;
 		}
 	}
+
+	return filledOrders;
 }
 
 void Limit::decrementHeadOrder(int units)

--- a/src/lib/limit.cpp
+++ b/src/lib/limit.cpp
@@ -1,27 +1,41 @@
 #include <limit.h>
 #include <iostream>
 
-Limit::Limit(std::shared_ptr<Order> order)
-: s_price(order->limit)
-, s_size(1)
-, s_volume(order->units)
+Limit::Limit(Order&& order)
+: s_price(order.limit)
+, s_volume(order.units)
 {
-	s_orders.emplace_back(order);
+	s_orders.push_back(std::move(order));
 }
 
-void Limit::addOrderToLimit(std::shared_ptr<Order> order)
+void Limit::addOrderToLimit(Order&& order)
 {
-	s_size += 1;
 	s_volume += order->units;
-	s_orders.emplace_back(order);
+	s_orders.push_back(std::move(order));
+}
+
+void Limit::fillUnits(int units)
+{
+	while(units){
+		auto& head = s_orders.front();
+		if(units >= head.units){
+			units -= head.units;
+			s_volume -= head.units;
+			orderMap.erase(head.id);
+			s_orders.pop_front();
+		}
+		else{
+			head.units -= units;
+			units = 0;
+		}
+	}
 }
 
 std::shared_ptr<Order> Limit::deleteHeadOrder()
 {
 	auto head = s_orders.front();
-	s_size -= 1;
 	s_volume -= head->units;
-	s_orders.erase(s_orders.begin());
+	s_orders.pop_front();
 
 	return head;
 }
@@ -29,5 +43,5 @@ std::shared_ptr<Order> Limit::deleteHeadOrder()
 void Limit::decrementHeadOrder(int units)
 {
 	s_volume -= units;
-	s_orders.front()->units -= units;
+	s_orders.front().units -= units;
 }

--- a/src/lib/limit.cpp
+++ b/src/lib/limit.cpp
@@ -6,12 +6,14 @@ Limit::Limit(std::shared_ptr<Order> order)
 , s_volume(order->units)
 {
 	s_orders.push_back(order);
+	s_orderMap[order->id] = order;
 }
 
 void Limit::addOrderToLimit(std::shared_ptr<Order> order)
 {
 	s_volume += order->units;
 	s_orders.push_back(order);
+	s_orderMap[order->id] = order;
 }
 
 void Limit::fillUnits(int units)
@@ -21,8 +23,9 @@ void Limit::fillUnits(int units)
 		if(units >= head->units){
 			units -= head->units;
 			s_volume -= head->units;
-			orderMap.erase(head->id);
+
 			s_orders.pop_front();
+			s_orderMap.erase(head->id);
 		}
 		else{
 			head->units -= units;

--- a/src/lib/limit.cpp
+++ b/src/lib/limit.cpp
@@ -1,47 +1,38 @@
 #include <limit.h>
 #include <iostream>
 
-Limit::Limit(Order&& order)
-: s_price(order.limit)
-, s_volume(order.units)
+Limit::Limit(std::shared_ptr<Order> order)
+: s_price(order->limit)
+, s_volume(order->units)
 {
-	s_orders.push_back(std::move(order));
+	s_orders.push_back(order);
 }
 
-void Limit::addOrderToLimit(Order&& order)
+void Limit::addOrderToLimit(std::shared_ptr<Order> order)
 {
 	s_volume += order->units;
-	s_orders.push_back(std::move(order));
+	s_orders.push_back(order);
 }
 
 void Limit::fillUnits(int units)
 {
 	while(units){
-		auto& head = s_orders.front();
-		if(units >= head.units){
-			units -= head.units;
-			s_volume -= head.units;
-			orderMap.erase(head.id);
+		auto head = s_orders.front();
+		if(units >= head->units){
+			units -= head->units;
+			s_volume -= head->units;
+			orderMap.erase(head->id);
 			s_orders.pop_front();
 		}
 		else{
-			head.units -= units;
+			head->units -= units;
 			units = 0;
 		}
 	}
 }
 
-std::shared_ptr<Order> Limit::deleteHeadOrder()
-{
-	auto head = s_orders.front();
-	s_volume -= head->units;
-	s_orders.pop_front();
-
-	return head;
-}
-
 void Limit::decrementHeadOrder(int units)
 {
 	s_volume -= units;
-	s_orders.front().units -= units;
+	s_orders.front()->units -= units;
 }

--- a/src/lib/limit.h
+++ b/src/lib/limit.h
@@ -7,16 +7,16 @@
 
 class Limit{
 public:
-	Limit(std::shared_ptr<Order> order);
+	Limit(Order&& order);
 
-	void addOrderToLimit(std::shared_ptr<Order> order);
+	void addOrderToLimit(Order&& order);
 
 	int price() const{
 		return s_price;
 	}
 
 	int size() const{
-		return s_size;
+		return s_orders.size();
 	}
 
 	int volume() const{
@@ -33,9 +33,9 @@ public:
 
 private:
 	int s_price;
-	int s_size; // number of Orders
 	int s_volume; // number of units
-	std::vector<std::shared_ptr<Order>> s_orders;
+	std::list<Order> s_orders;
+	std::unordered_map<int, std::list<Order>::iterator> orderMap;
 };
 
 #endif

--- a/src/lib/limit.h
+++ b/src/lib/limit.h
@@ -26,7 +26,16 @@ public:
 
 	void decrementHeadOrder(int units);
 
-	void fillUnits(int units);
+	std::vector<int> fillUnits(int units);
+
+	std::vector<int> getOrders(){
+		std::vector<int> orders;
+		for(const auto& pair: s_orderMap){
+			orders.push_back(pair.first);
+		}
+
+		return orders;
+	}
 
 	bool find(int id){
 		return s_orderMap.find(id) != s_orderMap.end();
@@ -36,7 +45,7 @@ private:
 	int s_price;
 	int s_volume; // number of units
 	std::list<std::shared_ptr<Order>> s_orders;
-	std::unordered_map<int, std::shared_ptr<Order>> s_orderMap;
+	std::unordered_map<int, std::list<std::shared_ptr<Order>>::iterator> s_orderMap;
 };
 
 #endif

--- a/src/lib/limit.h
+++ b/src/lib/limit.h
@@ -4,12 +4,13 @@
 #include <order.h>
 #include <memory>
 #include <vector>
+#include <list>
 
 class Limit{
 public:
-	Limit(Order&& order);
+	Limit(std::shared_ptr<Order> order);
 
-	void addOrderToLimit(Order&& order);
+	void addOrderToLimit(std::shared_ptr<Order> order);
 
 	int price() const{
 		return s_price;
@@ -23,19 +24,15 @@ public:
 		return s_volume;
 	}
 
-	std::shared_ptr<Order> deleteHeadOrder();
-
-	std::shared_ptr<Order> headOrder(){
-		return s_orders.front();
-	}
-
 	void decrementHeadOrder(int units);
+
+	void fillUnits(int units);
 
 private:
 	int s_price;
 	int s_volume; // number of units
-	std::list<Order> s_orders;
-	std::unordered_map<int, std::list<Order>::iterator> orderMap;
+	std::list<std::shared_ptr<Order>> s_orders;
+	std::unordered_map<int, std::list<std::shared_ptr<Order>>::iterator> orderMap;
 };
 
 #endif

--- a/src/lib/limit.h
+++ b/src/lib/limit.h
@@ -28,11 +28,15 @@ public:
 
 	void fillUnits(int units);
 
+	bool find(int id){
+		return s_orderMap.find(id) != s_orderMap.end();
+	}
+
 private:
 	int s_price;
 	int s_volume; // number of units
 	std::list<std::shared_ptr<Order>> s_orders;
-	std::unordered_map<int, std::list<std::shared_ptr<Order>>::iterator> orderMap;
+	std::unordered_map<int, std::shared_ptr<Order>> s_orderMap;
 };
 
 #endif

--- a/src/lib/order_book.cpp
+++ b/src/lib/order_book.cpp
@@ -9,15 +9,18 @@ void OrderBook::addOrder(std::shared_ptr<Order> order)
 {
 	if(auto it = limitMap.find(order->limit); it != limitMap.end()){
 		it->second->second.addOrderToLimit(order);
+		orderToLimitMap[order->id] = it->second;
 	}
 	else{
 		if(order->isBuy){
 			auto [mapIt, _] = buyTree.emplace(order->limit, Limit(order));
 			limitMap[order->limit] = mapIt;
+			orderToLimitMap[order->id] = mapIt;
 		}
 		else{
 			auto [mapIt, _] = sellTree.emplace(order->limit, Limit(order));
 			limitMap[order->limit] = mapIt;
+			orderToLimitMap[order->id] = mapIt;
 		}
 	}	
 
@@ -25,6 +28,7 @@ void OrderBook::addOrder(std::shared_ptr<Order> order)
 
 OrderStatus OrderBook::matchOrder(std::shared_ptr<Order> order)
 {
+	std::cout << "Matching Order " << order->id << std::endl;
 	OrderStatus orderStatus(order->units);
 	if(!order->isBuy)
 	{

--- a/src/lib/order_book.cpp
+++ b/src/lib/order_book.cpp
@@ -43,7 +43,6 @@ OrderStatus OrderBook::matchOrder(std::shared_ptr<Order> order)
 			}
 
 			// remove the limit from the tree and map, clean up memory
-			limitMap.erase(it->second.price());
 			it = std::make_reverse_iterator(buyTree.erase(std::prev(it.base())));
 		}
 	}
@@ -60,7 +59,6 @@ OrderStatus OrderBook::matchOrder(std::shared_ptr<Order> order)
 			}
 
 			// remove the limit from the tree and map, clean up memory
-			limitMap.erase(it->second.price());
 			it = sellTree.erase(it);
 		}
 	}
@@ -78,8 +76,12 @@ bool OrderBook::matchWithLimit(OrderStatus& orderStatus, Limit& current)
 			<< ", volume=" << current.volume()
 			<< std::endl;
 
+		for(auto& id : current.getOrders())
+		{
+			orderToLimitMap.erase(id);
+		}
+		limitMap.erase(current.price());
 		orderStatus.fill(current.volume(), current.price());
-
 		return true;
 	}
 
@@ -90,7 +92,11 @@ bool OrderBook::matchWithLimit(OrderStatus& orderStatus, Limit& current)
 		<< ": units matched = " << orderStatus.unitsUnfilled
 		<< std::endl;
 	
-	current.fillUnits(orderStatus.unitsUnfilled);
+	auto ordersToDelete = current.fillUnits(orderStatus.unitsUnfilled);
+	for(auto& id : ordersToDelete)
+	{
+		orderToLimitMap.erase(id);
+	}
 	orderStatus.fillRemaining(current.price());
 
 	return false;

--- a/src/lib/order_book.cpp
+++ b/src/lib/order_book.cpp
@@ -4,45 +4,29 @@
 
 OrderBook::OrderBook(){}
 
-void OrderBook::addFirstOrderAtLimit(std::shared_ptr<Order> order)
-{
-	std::shared_ptr<Limit> limit = std::make_shared<Limit>(order);
-	if(order->isBuy)
-	{
-		buyTree.emplace(order->limit, limit);
-	}
-	else
-	{
-		sellTree.emplace(order->limit, limit);
-	}
 
-	limitMap.emplace(order->limit, limit);
-	
-	std::cout << "Created " << (order->isBuy ? "buy" : "sell") << " limit=" << order->limit << " and added order id=" << order->id << ", units=" << order->units << std::endl;
+void OrderBook::addOrder(Order&& order)
+{
+	if(auto it = limitMap.find(order.limit); it != limitMap.end()){
+		it->second->second.addOrderToLimit(std::move(order));
+	}
+	else{
+		if(order.isBuy){
+			auto [mapIt, _] = buyTree.emplace(order.limit, Limit(std::move(order)));
+			limitMap[order.limit] = mapIt;
+		}
+		else{
+			auto [mapIt, _] = sellTree.emplace(order.limit, Limit(std::move(order)));
+			limitMap[order.limit] = mapIt;
+		}
+	}	
+
 }
 
-
-void OrderBook::addOrder(std::shared_ptr<Order> order)
+OrderStatus OrderBook::matchOrder(Order& order)
 {
-	if(auto it = limitMap.find(order->limit); it != limitMap.end())
-	{
-		std::shared_ptr<Limit> limitPtr = it->second;
-		limitPtr->addOrderToLimit(order);
-		std::cout << "Added order id=" << order->id << ", units=" << order->units << " to " << (order->isBuy ? "buy" : "sell") << " limit=" << order->limit << ". New size=" << limitPtr->size() << " volume=" << limitPtr->volume() << std::endl;
-
-	}
-	else
-	{
-		addFirstOrderAtLimit(order);
-	}
-
-	orderMap.emplace(order->id, order);
-}
-
-OrderStatus OrderBook::matchOrder(std::shared_ptr<Order> order)
-{
-	OrderStatus orderStatus(order->units);
-	if(!order->isBuy)
+	OrderStatus orderStatus(order.units);
+	if(!order.isBuy)
 	{
 		if(buyTree.empty())
 		{
@@ -53,7 +37,7 @@ OrderStatus OrderBook::matchOrder(std::shared_ptr<Order> order)
 		{
 			if(
 				orderStatus.unitsUnfilled == 0 or 
-				it->first < order->limit or
+				it->first < order.limit or
 				!matchWithLimit(orderStatus, it->second)
 			){
 				break;
@@ -82,33 +66,26 @@ OrderStatus OrderBook::matchOrder(std::shared_ptr<Order> order)
 			it = buyTree.erase(it);
 		}
 	}
-	order->units = orderStatus.unitsUnfilled;
+	order.units = orderStatus.unitsUnfilled;
 
 	return orderStatus;
 }
 
-bool OrderBook::matchWithLimit(OrderStatus& orderStatus, std::shared_ptr<Limit> current)
+bool OrderBook::matchWithLimit(OrderStatus& orderStatus, Limit& current)
 {
 	// if the volume of the current limit is less than the number of units to delete
 	// remove the whole limit from the tree
-	if(orderStatus.unitsUnfilled >= current->volume())
+	if(orderStatus.unitsUnfilled >= current.volume())
 	{
 		std::cout << "Incoming order matched all orders at limit=" << current->price()
-			<< ", size=" << current->size()
-			<< ", volume=" << current->volume()
+			<< ", size=" << current.size()
+			<< ", volume=" << current.volume()
 			<< std::endl;
 
-		orderStatus.fill(current->volume(), current->price());
-
-		// iterate through the orders in the limit and delete them from the map
-		// clean up their memory
-		while(current->size())
-		{
-			orderMap.erase(current->deleteHeadOrder()->id);
-		}
+		orderStatus.fill(current.volume(), current.price());
 
 		// remove the limit from the tree and map, clean up memory
-		limitMap.erase(current->price());
+		limitMap.erase(current.price());
 
 		return true;
 	}
@@ -117,54 +94,36 @@ bool OrderBook::matchWithLimit(OrderStatus& orderStatus, std::shared_ptr<Limit> 
 	else
 	{
 		std::cout << "Incoming order partial match with limit=" << current->price()
-			<< ", size=" << current->size()
-			<< ", volume=" << current->volume()
+			<< ", size=" << current.size()
+			<< ", volume=" << current.volume()
 			<< ": units matched = " << orderStatus.unitsUnfilled
 			<< std::endl;
-
-		// starting from the head order
-		while(orderStatus.unitsUnfilled)
-		{
-			// if more units to delete than that of the current order
-			// can just delete the order and update the doubly linked list
-			if(orderStatus.unitsUnfilled >= current->headOrder()->units)
-			{
-				// decrement the units remaining by the number of shares in current order
-				// update current limit's volume accordingly
-				orderStatus.fill(current->headOrder()->units, current->price());
-				orderMap.erase(current->deleteHeadOrder()->id);
-			}
-			// if not, subtract the remaining units from the current order
-			// update current limit's volume accordingly
-			else
-			{
-				current->decrementHeadOrder(orderStatus.unitsUnfilled);
-				orderStatus.fillRemaining(current->price());
-			}
-		}
+		
+		current.removeUnits(orderStatus.unitsUnfilled);
+		orderStatus.fillRemaining(current.price());
 	}
 
 	return false;
 }
 
-OrderStatus OrderBook::processOrder(std::shared_ptr<Order> order)
+OrderStatus OrderBook::processOrder(Order& order)
 {
-	std::cout << "Processing order id=" << order->id
-		<< ", isBuy=" << order->isBuy
-		<< ", units=" << order->units
-		<< ", limit=" << order->limit
-		<< ", timestamp=" << order->timestamp
-		<< ", security=" << order->security
+	std::cout << "Processing order id=" << order.id
+		<< ", isBuy=" << order.isBuy
+		<< ", units=" << order.units
+		<< ", limit=" << order.limit
+		<< ", timestamp=" << order.timestamp
+		<< ", security=" << order.security
 		<< std::endl;
 
 	OrderStatus orderStatus = matchOrder(order);
 
-	std::cout << "Order id=" << order->id << ": " << order->units << " units remaining after matching" << std::endl;
+	std::cout << "Order id=" << order.id << ": " << order.units << " units remaining after matching" << std::endl;
 
-	if(order->units and order->limit)
+	if(order.units and order.limit)
 	{
-		addOrder(order);
-		orderStatus.unitsInBook = order->units;
+		addOrder(std::move(order));
+		orderStatus.unitsInBook = order.units;
 	}
 
 	return orderStatus;

--- a/src/lib/order_book.h
+++ b/src/lib/order_book.h
@@ -43,7 +43,7 @@ class OrderBook{
 public:
 	OrderBook();
 	OrderStatus processOrder(std::shared_ptr<Order> order);
-	void addOrder(Order&& order);
+	void addOrder(std::shared_ptr<Order> order);
 	OrderStatus matchOrder(std::shared_ptr<Order> order);
 
 	bool isActive(){
@@ -74,10 +74,11 @@ private:
 	std::map<int, Limit> sellTree;
 
 	std::unordered_map<int, std::map<int, Limit>::iterator> limitMap;
+	std::unordered_map<int, std::shared_ptr<Order>> orderMap;
 
 	// match orderStatus.unfilledOrders with orders in the current Limit
 	// returns true if all orders in current is matched, false otherwise
-	bool matchWithLimit(OrderStatus& orderStatus, std::shared_ptr<Limit> current);
+	bool matchWithLimit(OrderStatus& orderStatus, Limit& current);
 };
 
 #endif

--- a/src/lib/order_book.h
+++ b/src/lib/order_book.h
@@ -43,7 +43,7 @@ class OrderBook{
 public:
 	OrderBook();
 	OrderStatus processOrder(std::shared_ptr<Order> order);
-	void addOrder(std::shared_ptr<Order> order);
+	void addOrder(Order&& order);
 	OrderStatus matchOrder(std::shared_ptr<Order> order);
 
 	bool isActive(){
@@ -70,12 +70,10 @@ public:
 	}
 
 private:
-	std::map<int, std::shared_ptr<Limit>> buyTree;
-	std::map<int, std::shared_ptr<Limit>> sellTree;
+	std::map<int, Limit> buyTree;
+	std::map<int, Limit> sellTree;
 
-	std::unordered_map<int, std::shared_ptr<Limit>> limitMap;
-	std::unordered_map<int, std::shared_ptr<Order>> orderMap;
-	void addFirstOrderAtLimit(std::shared_ptr<Order> order);
+	std::unordered_map<int, std::map<int, Limit>::iterator> limitMap;
 
 	// match orderStatus.unfilledOrders with orders in the current Limit
 	// returns true if all orders in current is matched, false otherwise

--- a/src/lib/order_book.h
+++ b/src/lib/order_book.h
@@ -57,8 +57,11 @@ public:
 	}
 
 	bool isOrderInMap(int id){
-		auto it = orderMap.find(id);
-		return it != orderMap.end();
+		if(auto it = orderToLimitMap.find(id); it != orderToLimitMap.end()){
+			return it->second->second.find(id);
+		}
+
+		return false;
 	}
 
 	int getHighestBuy() const{
@@ -74,7 +77,7 @@ private:
 	std::map<int, Limit> sellTree;
 
 	std::unordered_map<int, std::map<int, Limit>::iterator> limitMap;
-	std::unordered_map<int, std::shared_ptr<Order>> orderMap;
+	std::unordered_map<int, std::map<int, Limit>::iterator> orderToLimitMap;
 
 	// match orderStatus.unfilledOrders with orders in the current Limit
 	// returns true if all orders in current is matched, false otherwise

--- a/src/proto/CMakeLists.txt
+++ b/src/proto/CMakeLists.txt
@@ -1,4 +1,5 @@
 find_package(Protobuf REQUIRED)
+find_package(absl REQUIRED)
 
 include_directories(${Protobuf_INCLUDE_DIRS})
 
@@ -10,13 +11,21 @@ protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS ${PROTO_FILES})
 
 add_library(protolib 
 	${PROTO_SRCS}
+	${PROTO_HDRS}
 )
 
 target_link_libraries(protolib PRIVATE
-	protobuf
+	protobuf::libprotobuf
+	absl::base
+	absl::strings
+	absl::log
+	absl::raw_logging_internal
+	absl::check
+	${Protobuf_LIBRARIES}
 )
 
 target_include_directories(protolib PUBLIC 
 	${CMAKE_CURRENT_BINARY_DIR}
+	${Protobuf_INCLUDE_DIRS}
 )
 

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -1,13 +1,14 @@
+find_package(GTest REQUIRED)
+
 add_executable(matcher.t
 	order_book.t.cpp
 )
 
 target_link_libraries(matcher.t PRIVATE
-	gtest
-	gtest_main
-	rt
+	GTest::gtest
+	GTest::gtest_main
+	GTest::gmock
 	pthread
-	gmock
 	matcherlib
 )
 


### PR DESCRIPTION
- Limit holds orders in a list
- Limit also contains an unordered_map mapping orderId to the list iterator to provide O(1) lookup
- OrderBook contains an unordered_map mapping orderId to the map<Limit>::iterator

When a Limit is fully matched, `matchWithLimit` calls `Limit.getOrders()` which returns a vector of all orderIds in the Limit. It then iterates through these and delete them from the unordered_map before deleting the limit from the limitMap and tree.

If it is partially matched, `Limit.fillUnits` also returns a vector of orderIds that have been filled for the OrderBook to delete them.

With these changes, updating/deleting an order becomes O(1). OrderBook looks up orderToLimitMap with the orderId to get the right Limit. From there, look up s_orderMap to get to the right iterator in s_orders.